### PR TITLE
Remove err from task fetcher interface

### DIFF
--- a/pkg/workspace/tasks/client.go
+++ b/pkg/workspace/tasks/client.go
@@ -100,17 +100,12 @@ func (c *Client) ListDocuments() []string {
 	return documents
 }
 
-func (c *Client) ListTasks(fetcher TaskFetcher, filters ...TaskFilter) ([]ast.Task, error) {
-	tasks, err := fetcher(c)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) ListTasks(fetcher TaskFetcher, filters ...TaskFilter) []ast.Task {
+	tasks := fetcher(c)
 	for _, filter := range filters {
 		tasks = filterTasks(tasks, filter)
 	}
-
-	return tasks, nil
+	return tasks
 }
 func filterTasks(tasks []ast.Task, filter TaskFilter) []ast.Task {
 	var filtered []ast.Task

--- a/pkg/workspace/tasks/client_test.go
+++ b/pkg/workspace/tasks/client_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 	// Assert that we eventually get the correct number of documents and tasks
 	waitFor, tick := 3*time.Second, 200*time.Millisecond
 	assert.Eventually(t, func() bool { return len(client.ListDocuments()) == len(events) }, waitFor, tick)
-	assert.Eventually(t, func() bool { t, _ := client.ListTasks(tasks.FetchAllTasks()); return len(t) == 4 }, waitFor, tick)
+	assert.Eventually(t, func() bool { return len(client.ListTasks(tasks.FetchAllTasks())) == 4 }, waitFor, tick)
 }
 
 func TestClient_InitialLoadWaiter(t *testing.T) {
@@ -54,6 +54,5 @@ func TestClient_InitialLoadWaiter(t *testing.T) {
 
 	// Assert that the client has the correct number of documents and tasks
 	assert.Equal(t, len(events), len(client.ListDocuments()))
-	tasks, _ := client.ListTasks(tasks.FetchAllTasks())
-	assert.Equal(t, 4, len(tasks))
+	assert.Equal(t, 4, len(client.ListTasks(tasks.FetchAllTasks())))
 }

--- a/pkg/workspace/tasks/fetchers.go
+++ b/pkg/workspace/tasks/fetchers.go
@@ -16,10 +16,10 @@ package tasks
 
 import "github.com/notedownorg/notedown/pkg/ast"
 
-type TaskFetcher func(c *Client) ([]ast.Task, error)
+type TaskFetcher func(c *Client) []ast.Task
 
 func FetchAllTasks() TaskFetcher {
-	return func(c *Client) ([]ast.Task, error) {
+	return func(c *Client) []ast.Task {
 		var tasks []ast.Task
 		c.mutex.RLock()
 		for _, document := range c.cache {
@@ -28,18 +28,18 @@ func FetchAllTasks() TaskFetcher {
 			}
 		}
 		c.mutex.RUnlock()
-		return tasks, nil
+		return tasks
 	}
 }
 
 func FetchTasksForDocument(document string) TaskFetcher {
-	return func(c *Client) ([]ast.Task, error) {
+	return func(c *Client) []ast.Task {
 		var tasks []ast.Task
 		c.mutex.RLock()
 		for _, task := range c.cache[document] {
 			tasks = append(tasks, *task)
 		}
 		c.mutex.RUnlock()
-		return tasks, nil
+		return tasks
 	}
 }

--- a/pkg/workspace/tasks/fetchers_test.go
+++ b/pkg/workspace/tasks/fetchers_test.go
@@ -24,19 +24,15 @@ import (
 func TestFetchAllTasks(t *testing.T) {
 	events := defaultEvents()
 	c, _ := buildClient(events)
-	tasks, err := c.ListTasks(tasks.FetchAllTasks())
+	tasks := c.ListTasks(tasks.FetchAllTasks())
 	wantTasks := append(events[0].Document.Tasks, events[1].Document.Tasks...)
-
-	assert.NoError(t, err)
 	assert.ElementsMatch(t, wantTasks, tasks)
 }
 
 func TestFetchTasksForDocument(t *testing.T) {
 	events := defaultEvents()
 	c, _ := buildClient(events)
-	tasks, err := c.ListTasks(tasks.FetchTasksForDocument("two.md"))
+	tasks := c.ListTasks(tasks.FetchTasksForDocument("two.md"))
 	wantTasks := events[1].Document.Tasks
-
-	assert.NoError(t, err)
 	assert.ElementsMatch(t, wantTasks, tasks)
 }

--- a/pkg/workspace/tasks/filters_test.go
+++ b/pkg/workspace/tasks/filters_test.go
@@ -54,9 +54,7 @@ func TestFilters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tasks, err := c.ListTasks(tasks.FetchAllTasks(), tt.filter)
-			assert.NoError(t, err)
-			assert.ElementsMatch(t, tt.wantTasks, tasks)
+			assert.ElementsMatch(t, tt.wantTasks, c.ListTasks(tasks.FetchAllTasks(), tt.filter))
 		})
 	}
 


### PR DESCRIPTION
As we're reading from memory it shouldn't be possible to experience an error, if we need to add it back in the future we can though