### PR TITLE
Fix task diagnostics false positives for wikilinks and markdown links

### DIFF
--- a/lsp/pkg/notedownls/diagnostics.go
+++ b/lsp/pkg/notedownls/diagnostics.go
@@ -140,8 +140,9 @@ func (s *Server) findInvalidTaskCheckboxes(doc *parser.Document, content string,
 	var diagnostics []lsp.Diagnostic
 
 	// Step 1: Use regex to find all potential task checkbox patterns in list items
-	// Pattern: line start + list marker (-, *, +, or number.) + whitespace + [text]
-	taskRegex := regexp.MustCompile(`(?m)^(\s*[-*+]|\s*\d+\.)\s*(\[([^\]]*)\])`)
+	// Pattern: line start + list marker (-, *, +, or number.) + whitespace + [text] + whitespace
+	// The trailing whitespace requirement distinguishes task checkboxes from wikilinks/markdown links
+	taskRegex := regexp.MustCompile(`(?m)^(\s*[-*+]|\s*\d+\.)\s*(\[([^\]]*)\])\s`)
 	matches := taskRegex.FindAllStringSubmatchIndex(content, -1)
 
 	if len(matches) == 0 {

--- a/lsp/pkg/notedownls/diagnostics_test.go
+++ b/lsp/pkg/notedownls/diagnostics_test.go
@@ -146,6 +146,61 @@ Paragraph with [x] checkbox not in list.`,
 				},
 			},
 		},
+		{
+			name: "wikilinks and markdown links should be ignored",
+			content: `# Mixed Content
+
+- [[wikilink]] Regular list item with wikilink
+- [markdown-link](http://example.com) Regular list item with markdown link
+- [[docs/architecture]] Full path wikilink
+- [[target|display]] Wikilink with display text
+- [x] Valid task
+- [invalid] Invalid task that should be flagged
+- [ ] Another valid task
+
+Regular paragraph with [brackets] that should be ignored.
+`,
+			expectedCount: 1,
+			expectedCodes: []string{"invalid-task-state"},
+			expectedRanges: []lsp.Range{
+				{
+					Start: lsp.Position{Line: 7, Character: 2},
+					End:   lsp.Position{Line: 7, Character: 11},
+				},
+			},
+		},
+		{
+			name: "edge cases with complex brackets and spacing",
+			content: `# Edge Cases
+
+- [x]Valid task without space after bracket should not be detected
+- [ ] Valid task with space
+- [invalid]No space after bracket should not be detected  
+- [wrong] Space after bracket should be detected as invalid
+- [[wikilink]] Should be ignored
+- [[complex/path/file]] Should be ignored
+- [[target|display text]] Should be ignored
+- [link text](https://example.com) Should be ignored
+- [complex link text](path/to/file.md) Should be ignored
+- Text with [brackets] in middle should be ignored
+
+1. [x] Valid numbered task
+2. [bad] Invalid numbered task
+3. [[numbered/wikilink]] Should be ignored
+`,
+			expectedCount: 2,
+			expectedCodes: []string{"invalid-task-state", "invalid-task-state"},
+			expectedRanges: []lsp.Range{
+				{
+					Start: lsp.Position{Line: 5, Character: 2},
+					End:   lsp.Position{Line: 5, Character: 9},
+				},
+				{
+					Start: lsp.Position{Line: 14, Character: 3},
+					End:   lsp.Position{Line: 14, Character: 8},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fixed task diagnostics incorrectly flagging wikilinks and markdown links as invalid task states
- Updated regex pattern to require whitespace after closing bracket to distinguish task checkboxes from other bracket patterns
- Added comprehensive test coverage for edge cases including complex wikilinks and markdown links

## Changes

- **diagnostics.go**: Modified regex pattern from `(\[([^\]]*)\])` to `(\[([^\]]*)\])\s` to require trailing whitespace
- **diagnostics_test.go**: Added two new test cases covering wikilinks, markdown links, and edge cases

## Test Coverage

- ✅ Wikilinks in lists are ignored: `- [[wikilink]]`, `- [[docs/architecture]]`, `- [[target|display]]`
- ✅ Markdown links in lists are ignored: `- [text](url)`, `- [complex link](path)`
- ✅ Valid tasks continue to work: `- [x] task`, `- [ ] task`
- ✅ Invalid tasks continue to be flagged: `- [invalid] task`
- ✅ Edge cases handled properly: tasks without trailing spaces are ignored

## Impact

This fix eliminates false positive diagnostics that were incorrectly flagging legitimate wikilinks and markdown links in list items as invalid task states, improving the user experience when working with mixed content documents.