### PR TITLE
Add description to list text object keymap

### DIFF
--- a/notedown-nvim/lua/notedown/init.lua
+++ b/notedown-nvim/lua/notedown/init.lua
@@ -199,7 +199,7 @@ function M.setup_list_text_object()
 		else
 			vim.notify("No list item found at cursor", vim.log.levels.WARN)
 		end
-	end, { buffer = true, silent = true })
+	end, { buffer = true, silent = true, desc = "list item" })
 end
 
 return M


### PR DESCRIPTION
## Summary
- Add 'list item' description to the 'al' text object keymap in Neovim plugin
- Improves discoverability in which-key and similar help overlays
- Users will now see descriptions for yal, dal, cal, val commands in help UI