### PR TITLE
fix: add version 2 to GoReleaser configurations

### DIFF
--- a/.goreleaser.notedown-language-server.nightly.yaml
+++ b/.goreleaser.notedown-language-server.nightly.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
+
 project_name: notedown-language-server
 
 version_template: "{{ .Env.NIGHTLY_VERSION }}"

--- a/.goreleaser.notedown-language-server.yaml
+++ b/.goreleaser.notedown-language-server.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: 2
+
 project_name: notedown-language-server
 
 before:


### PR DESCRIPTION
Add required version: 2 field to both GoReleaser configs to fix configuration compatibility with latest GoReleaser