### PR TITLE
fix: remove invalid version_template from project level

### DIFF
--- a/.goreleaser.notedown-language-server.nightly.yaml
+++ b/.goreleaser.notedown-language-server.nightly.yaml
@@ -16,8 +16,6 @@ version: 2
 
 project_name: notedown-language-server
 
-version_template: "{{ .Env.NIGHTLY_VERSION }}"
-
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
Remove version_template field from project level in nightly config as it's not valid in GoReleaser v2 - version is handled by snapshot.version_template